### PR TITLE
docs: add testing instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,7 @@ Always use `make` commands: `make build`, `make test`, `make lint`
 
 Before opening a PR: `make lint && make test && make build`
 
+## Writing Tests
+
+Tests use **Ginkgo v2 + Gomega** (BDD-style). Create a `*_suite_test.go` file per package, then use `Describe/Context/It` blocks with Gomega matchers (e.g., `Expect(value).To(Equal(expected))`).
+


### PR DESCRIPTION
Add brief instructions for writing tests using Ginkgo v2 + Gomega BDD-style framework.

This provides a quick reference for developers on how to write tests following the established patterns in the codebase.