### PR TITLE
feat: Add CI/CD support with environment variable authentication and JSON output

### DIFF
--- a/cmd/blueprint/create.go
+++ b/cmd/blueprint/create.go
@@ -35,13 +35,12 @@ Optional flags:
   --branch          Branch name (for CI/CD workflows)
   --author          Author name (for CI/CD workflows)
   --repository      Repository name/URL (overrides auto-detection)
-  -o, --output      Output format (json, yaml) - global flag
 
-Environment variables:
+Command-specific environment variables:
   LISSTO_REPOSITORY    Override repository auto-detection
   LISSTO_COMPOSE_FILE  Override compose file path (used when no argument provided)
-  LISSTO_API_KEY       API key for CI/CD authentication
-  LISSTO_API_URL       API URL for CI/CD authentication`,
+
+See 'lissto --help' for global flags and environment variables.`,
 	Args:          cobra.MaximumNArgs(1),
 	RunE:          runCreate,
 	SilenceUsage:  true, // Don't show usage on errors
@@ -119,7 +118,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	out := cmdutil.NewOutputContext(cmd)
 
 	// Load environment variable overrides
-	overrides := cmdutil.LoadOverrides()
+	overrides := cmdutil.LoadEnvOverrides()
 
 	// Determine compose file: argument > env var
 	var composeFile string

--- a/cmd/blueprint_wizard.go
+++ b/cmd/blueprint_wizard.go
@@ -82,7 +82,7 @@ func blueprintWizardFlow(_ *cobra.Command, apiClient *client.Client) (*client.Bl
 	var repository string
 
 	// Load environment variable overrides
-	overrides := cmdutil.LoadOverrides()
+	overrides := cmdutil.LoadEnvOverrides()
 
 	// Check for compose file override
 	if overrides.HasComposeFile() {

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -225,6 +225,9 @@ func runCreateStack(cmd *cobra.Command, args []string) error {
 	// Create output context for handling quiet mode (JSON/YAML output)
 	out := cmdutil.NewOutputContext(cmd)
 
+	// Load all environment overrides once
+	overrides := cmdutil.LoadEnvOverrides()
+
 	// Get API client (handles env var auth and config-based auth)
 	apiClient, err := cmdutil.GetAPIClient()
 	if err != nil {
@@ -233,10 +236,6 @@ func runCreateStack(cmd *cobra.Command, args []string) error {
 
 	// Track if blueprint was selected interactively (to show/hide Back button)
 	blueprintWasInteractive := createBlueprint == ""
-
-	// Check if using env var authentication (CI/CD mode)
-	authOverrides := cmdutil.LoadAuthOverrides()
-	isCICDMode := authOverrides.IsConfigured()
 
 	// Step 1: Determine environment (once, outside blueprint loop)
 	envToUse := createEnv
@@ -247,7 +246,7 @@ func runCreateStack(cmd *cobra.Command, args []string) error {
 
 	if envToUse == "" {
 		// In CI/CD mode with env vars, environment must be provided
-		if isCICDMode {
+		if overrides.IsCICDMode() {
 			return fmt.Errorf("--env flag is required when using environment variable authentication")
 		}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,7 +36,19 @@ var rootCmd = &cobra.Command{
 	Use:   "lissto",
 	Short: "Lissto CLI - Manage your Lissto resources",
 	Long: `Lissto CLI is a command-line tool for managing Lissto resources
-including blueprints, stacks, and environments.`,
+including blueprints, stacks, and environments.
+
+Global Flags:
+  -o, --output      Output format (json, yaml, wide)
+      --context     Override current context
+      --env         Override current environment
+
+Environment Variables (CI/CD):
+  LISSTO_API_KEY    API key for headless CI/CD authentication
+  LISSTO_API_URL    API URL for headless CI/CD authentication
+
+When both LISSTO_API_KEY and LISSTO_API_URL are set, the CLI operates in
+CI/CD mode without requiring 'lissto login' or a kubeconfig.`,
 	SilenceUsage: true, // Don't show usage on errors
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		// Check for updates in the background (respects 24h cache)

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -54,7 +54,7 @@ func init() {
 
 func runVerify(cmd *cobra.Command, args []string) error {
 	// Load environment variable overrides
-	overrides := cmdutil.LoadOverrides()
+	overrides := cmdutil.LoadEnvOverrides()
 
 	// Determine compose file: argument > env var
 	var composePath string

--- a/pkg/cmdutil/cmdutil.go
+++ b/pkg/cmdutil/cmdutil.go
@@ -16,9 +16,9 @@ import (
 // This enables headless CI/CD usage (e.g., GitHub Actions) without requiring login.
 func GetAPIClient() (*client.Client, error) {
 	// Check for environment variable authentication first (CI/CD mode)
-	authOverrides := LoadAuthOverrides()
-	if authOverrides.IsConfigured() {
-		return client.NewClient(authOverrides.APIURL, authOverrides.APIKey), nil
+	overrides := LoadEnvOverrides()
+	if overrides.IsCICDMode() {
+		return client.NewClient(overrides.APIURL, overrides.APIKey), nil
 	}
 
 	// Fall back to config-based authentication
@@ -46,12 +46,12 @@ func GetAPIClientAndEnv(cmd *cobra.Command) (*client.Client, string, error) {
 	envName, _ := cmd.Flags().GetString("env")
 
 	// Check for environment variable authentication first (CI/CD mode)
-	authOverrides := LoadAuthOverrides()
-	if authOverrides.IsConfigured() {
+	overrides := LoadEnvOverrides()
+	if overrides.IsCICDMode() {
 		if envName == "" {
 			return nil, "", fmt.Errorf("--env flag is required when using environment variable authentication")
 		}
-		return client.NewClient(authOverrides.APIURL, authOverrides.APIKey), envName, nil
+		return client.NewClient(overrides.APIURL, overrides.APIKey), envName, nil
 	}
 
 	// Fall back to config-based authentication

--- a/pkg/cmdutil/output_context.go
+++ b/pkg/cmdutil/output_context.go
@@ -1,0 +1,50 @@
+package cmdutil
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// OutputContext provides context-aware output handling for commands.
+// It suppresses progress/status messages when structured output (JSON/YAML) is requested,
+// ensuring clean machine-readable output for CI/CD pipelines.
+type OutputContext struct {
+	cmd    *cobra.Command
+	format string
+}
+
+// NewOutputContext creates a new output context from a command
+func NewOutputContext(cmd *cobra.Command) *OutputContext {
+	return &OutputContext{
+		cmd:    cmd,
+		format: GetOutputFormat(cmd),
+	}
+}
+
+// IsQuiet returns true if output format requires quiet mode (json/yaml).
+// In quiet mode, progress messages and emojis should be suppressed.
+func (o *OutputContext) IsQuiet() bool {
+	return o.format == "json" || o.format == "yaml"
+}
+
+// Printf prints formatted text only if not in quiet mode
+func (o *OutputContext) Printf(format string, a ...interface{}) {
+	if !o.IsQuiet() {
+		fmt.Printf(format, a...)
+	}
+}
+
+// Println prints a line only if not in quiet mode
+func (o *OutputContext) Println(a ...interface{}) {
+	if !o.IsQuiet() {
+		fmt.Println(a...)
+	}
+}
+
+// PrintResult outputs the result using the unified PrintOutput pattern.
+// For JSON/YAML formats, it serializes the data struct.
+// For default format, it calls the customFormatter function.
+func (o *OutputContext) PrintResult(data interface{}, customFormatter func()) error {
+	return PrintOutput(o.cmd, data, customFormatter)
+}

--- a/pkg/cmdutil/overrides.go
+++ b/pkg/cmdutil/overrides.go
@@ -2,57 +2,51 @@ package cmdutil
 
 import "os"
 
-// Environment variable names for overriding auto-detection
+// Environment variable names
 const (
+	// CI/CD authentication
+	EnvAPIKey = "LISSTO_API_KEY"
+	EnvAPIURL = "LISSTO_API_URL"
+
+	// Behavior overrides
 	EnvOverrideRepository  = "LISSTO_REPOSITORY"
 	EnvOverrideComposeFile = "LISSTO_COMPOSE_FILE"
 )
 
-// Environment variable names for CI/CD authentication (e.g., GitHub Actions)
-const (
-	EnvAPIKey = "LISSTO_API_KEY"
-	EnvAPIURL = "LISSTO_API_URL"
-)
+// EnvOverrides holds all environment variable overrides for CLI behavior.
+// This includes both authentication overrides (for CI/CD) and
+// behavior overrides (repository, compose file).
+type EnvOverrides struct {
+	// Authentication (CI/CD mode)
+	APIKey string // LISSTO_API_KEY - Direct API key for headless CI/CD
+	APIURL string // LISSTO_API_URL - Direct API URL for headless CI/CD
 
-// Overrides holds environment variable overrides for CLI behavior
-type Overrides struct {
-	Repository  string // Overrides git repository auto-detection
-	ComposeFile string // Overrides compose file auto-detection
+	// Behavior overrides
+	Repository  string // LISSTO_REPOSITORY - Override git repo auto-detection
+	ComposeFile string // LISSTO_COMPOSE_FILE - Override compose file path
 }
 
-// AuthOverrides holds environment variable overrides for API authentication
-type AuthOverrides struct {
-	APIKey string // Direct API key for CI/CD environments
-	APIURL string // Direct API URL for CI/CD environments
-}
-
-// LoadOverrides reads all override environment variables
-func LoadOverrides() Overrides {
-	return Overrides{
+// LoadEnvOverrides reads all environment variable overrides
+func LoadEnvOverrides() EnvOverrides {
+	return EnvOverrides{
+		APIKey:      os.Getenv(EnvAPIKey),
+		APIURL:      os.Getenv(EnvAPIURL),
 		Repository:  os.Getenv(EnvOverrideRepository),
 		ComposeFile: os.Getenv(EnvOverrideComposeFile),
 	}
 }
 
-// LoadAuthOverrides reads authentication override environment variables
-func LoadAuthOverrides() AuthOverrides {
-	return AuthOverrides{
-		APIKey: os.Getenv(EnvAPIKey),
-		APIURL: os.Getenv(EnvAPIURL),
-	}
+// IsCICDMode returns true if both API key and URL are set (headless CI/CD mode)
+func (o EnvOverrides) IsCICDMode() bool {
+	return o.APIKey != "" && o.APIURL != ""
 }
 
 // HasRepository returns true if repository override is set
-func (o Overrides) HasRepository() bool {
+func (o EnvOverrides) HasRepository() bool {
 	return o.Repository != ""
 }
 
 // HasComposeFile returns true if compose file override is set
-func (o Overrides) HasComposeFile() bool {
+func (o EnvOverrides) HasComposeFile() bool {
 	return o.ComposeFile != ""
-}
-
-// IsConfigured returns true if both API key and URL are set
-func (a AuthOverrides) IsConfigured() bool {
-	return a.APIKey != "" && a.APIURL != ""
 }

--- a/pkg/cmdutil/overrides.go
+++ b/pkg/cmdutil/overrides.go
@@ -8,10 +8,22 @@ const (
 	EnvOverrideComposeFile = "LISSTO_COMPOSE_FILE"
 )
 
+// Environment variable names for CI/CD authentication (e.g., GitHub Actions)
+const (
+	EnvAPIKey = "LISSTO_API_KEY"
+	EnvAPIURL = "LISSTO_API_URL"
+)
+
 // Overrides holds environment variable overrides for CLI behavior
 type Overrides struct {
 	Repository  string // Overrides git repository auto-detection
 	ComposeFile string // Overrides compose file auto-detection
+}
+
+// AuthOverrides holds environment variable overrides for API authentication
+type AuthOverrides struct {
+	APIKey string // Direct API key for CI/CD environments
+	APIURL string // Direct API URL for CI/CD environments
 }
 
 // LoadOverrides reads all override environment variables
@@ -19,6 +31,14 @@ func LoadOverrides() Overrides {
 	return Overrides{
 		Repository:  os.Getenv(EnvOverrideRepository),
 		ComposeFile: os.Getenv(EnvOverrideComposeFile),
+	}
+}
+
+// LoadAuthOverrides reads authentication override environment variables
+func LoadAuthOverrides() AuthOverrides {
+	return AuthOverrides{
+		APIKey: os.Getenv(EnvAPIKey),
+		APIURL: os.Getenv(EnvAPIURL),
 	}
 }
 
@@ -30,4 +50,9 @@ func (o Overrides) HasRepository() bool {
 // HasComposeFile returns true if compose file override is set
 func (o Overrides) HasComposeFile() bool {
 	return o.ComposeFile != ""
+}
+
+// IsConfigured returns true if both API key and URL are set
+func (a AuthOverrides) IsConfigured() bool {
+	return a.APIKey != "" && a.APIURL != ""
 }


### PR DESCRIPTION
## Summary

This PR adds support for headless CI/CD usage (e.g., GitHub Actions) by enabling environment variable authentication and JSON output for key commands.

## Changes

### 1. Environment Variable Authentication

New environment variables for CI/CD authentication:
- `LISSTO_API_KEY`: Direct API key for authentication
- `LISSTO_API_URL`: Direct API URL (bypasses k8s discovery)

When both are set, commands work without requiring `lissto login` or a kubeconfig.

**Modified files:**
- `pkg/cmdutil/overrides.go` - Added `AuthOverrides` struct and `LoadAuthOverrides()` function
- `pkg/cmdutil/cmdutil.go` - Updated `GetAPIClient()` and `GetAPIClientAndEnv()` to check env vars first

### 2. JSON Output Support

Added `--output json` flag support for CI/CD-friendly output:

| Command | JSON Output |
|---------|-------------|
| `lissto blueprint create --output json` | `{"id": "...", "repository": "...", "branch": "...", "author": "..."}` |
| `lissto create stack --output json` | `{"stack_id": "...", "blueprint_id": "...", "environment": "...", "exposed": [...]}` |
| `lissto update --output json` | `{"stack_id": "...", "updated_services": [...], "status": "success/no-changes"}` |

**Modified files:**
- `cmd/blueprint/create.go` - Added `BlueprintCreateResult` struct and JSON output
- `cmd/create.go` - Added `StackCreateResult` struct and JSON output
- `cmd/update.go` - Added `UpdateResult` struct and JSON output

### 3. Non-interactive Mode Improvements

- Better error messages when required flags are missing in env var auth mode
- Suppressed progress output (emojis, status messages) when using JSON format

## Usage Examples

### CI/CD with Environment Variables

```bash
export LISSTO_API_KEY="your-api-key"
export LISSTO_API_URL="https://api.lissto.example.com"

# Create blueprint
lissto blueprint create docker-compose.yml --output json

# Create stack
lissto create stack --blueprint my-blueprint --env production --non-interactive --output json

# Update stack
lissto update --stack my-stack --env production --branch main --yes --output json
```

### In GitHub Actions

```yaml
- name: Deploy to Lissto
  env:
    LISSTO_API_KEY: ${{ secrets.LISSTO_API_KEY }}
    LISSTO_API_URL: ${{ secrets.LISSTO_API_URL }}
  run: |
    RESULT=$(lissto create stack --blueprint my-bp --env prod --non-interactive --output json)
    STACK_ID=$(echo "$RESULT" | jq -r '.stack_id')
    echo "Deployed stack: $STACK_ID"
```

## Related

This PR enables the upcoming `lissto-dev/actions` GitHub Actions repository which will provide:
- `lissto-dev/actions/blueprint-create` - Create blueprints from docker-compose
- `lissto-dev/actions/deploy` - Full deployment (blueprint + stack)
- `lissto-dev/actions/update` - Update existing stacks

## Testing

- [ ] Tested blueprint create with `--output json`
- [ ] Tested stack create with `--output json`
- [ ] Tested update with `--output json`
- [ ] Tested env var authentication without kubeconfig


@daniel-ro can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)