### PR TITLE
fix: use DOCKER_IMAGE as-is without appending version tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,12 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag_suffix:
+        description: 'Custom tag suffix (e.g., sha-abc123 for testing)'
+        required: false
+        default: ''
 
 env:
   DOCKER_IMAGE: lissto/cli
@@ -19,6 +25,7 @@ jobs:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
     if: >
+      github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     permissions:
@@ -43,13 +50,20 @@ jobs:
       - name: Extract metadata
         id: meta
         run: |
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          # Handle workflow_dispatch with custom tag
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.tag_suffix }}" ]]; then
+            echo "is_tag=false" >> $GITHUB_OUTPUT
+            echo "is_stable=false" >> $GITHUB_OUTPUT
+            echo "version=${{ inputs.tag_suffix }}" >> $GITHUB_OUTPUT
+            echo "docker_tag=${{ inputs.tag_suffix }}" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
             TAG_NAME=${GITHUB_REF#refs/tags/}
             # Remove 'v' prefix for version (v1.0.0 -> 1.0.0)
             VERSION=${TAG_NAME#v}
             echo "is_tag=true" >> $GITHUB_OUTPUT
             echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
             echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "docker_tag=$TAG_NAME" >> $GITHUB_OUTPUT
             if [[ "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               echo "is_stable=true" >> $GITHUB_OUTPUT
             else
@@ -59,23 +73,18 @@ jobs:
             echo "is_tag=false" >> $GITHUB_OUTPUT
             echo "is_stable=false" >> $GITHUB_OUTPUT
             echo "version=main" >> $GITHUB_OUTPUT
+            echo "docker_tag=main" >> $GITHUB_OUTPUT
           fi
 
       - name: Build and push Docker image
         run: |
-          # Determine tags
-          TAGS="-t ${{ env.DOCKER_IMAGE }}:${{ steps.meta.outputs.is_tag == 'true' && steps.meta.outputs.tag_name || 'main' }}"
-          if [[ "${{ steps.meta.outputs.is_stable }}" == "true" ]]; then
-            TAGS="$TAGS -t ${{ env.DOCKER_IMAGE }}:latest"
-          fi
-
           make docker-push \
             VERSION=${{ steps.meta.outputs.version }} \
             COMMIT=${{ github.sha }} \
             BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
             CACHE_FROM=type=gha \
             CACHE_TO=type=gha,mode=max \
-            DOCKER_IMAGE=${{ env.DOCKER_IMAGE }}:${{ steps.meta.outputs.is_tag == 'true' && steps.meta.outputs.tag_name || 'main' }}
+            DOCKER_IMAGE=${{ env.DOCKER_IMAGE }}:${{ steps.meta.outputs.docker_tag }}
 
       - name: Push latest tag (stable releases only)
         if: steps.meta.outputs.is_stable == 'true'
@@ -89,7 +98,7 @@ jobs:
 
       - name: Show image info
         run: |
-          echo "Published: ${{ env.DOCKER_IMAGE }}:${{ steps.meta.outputs.is_tag == 'true' && steps.meta.outputs.tag_name || 'main' }}"
+          echo "Published: ${{ env.DOCKER_IMAGE }}:${{ steps.meta.outputs.docker_tag }}"
           if [[ "${{ steps.meta.outputs.is_stable }}" == "true" ]]; then
             echo "Published: ${{ env.DOCKER_IMAGE }}:latest"
           fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Build stage
 FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS builder
 
-RUN apk add --no-cache make git
+RUN apk add --no-cache make git bash
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ docker-push: ## Build and push multi-arch Docker image.
 		--build-arg BUILD_DATE=$(BUILD_DATE) \
 		$(if $(CACHE_FROM),--cache-from $(CACHE_FROM),) \
 		$(if $(CACHE_TO),--cache-to $(CACHE_TO),) \
-		-t $(DOCKER_IMAGE):$(VERSION) \
+		-t $(DOCKER_IMAGE) \
 		--push .
 
 ##@ Release


### PR DESCRIPTION
## Problem

The Docker build workflow was failing with:
```
ERROR: failed to build: invalid tag "lissto/cli:main:main": invalid reference format
```

## Root Cause

1. **Double tag**: The `docker-push` Makefile target was appending `:$(VERSION)` to `DOCKER_IMAGE`, but CI already provides the full `image:tag` via the `DOCKER_IMAGE` variable. This caused invalid double tags like `lissto/cli:main:main`.

2. **Missing bash**: The Makefile requires bash (`SHELL = /usr/bin/env bash -o pipefail`) but the Alpine builder image did not have bash installed.

## Fix

1. **Makefile**: Remove the `:$(VERSION)` suffix from the `docker-push` target since CI already passes the complete `DOCKER_IMAGE` with tag
2. **Dockerfile**: Add `bash` to the builder stage dependencies
3. **docker.yml**: Add `workflow_dispatch` trigger for manual testing with custom tags
4. **docker.yml**: Simplify tag handling with a unified `docker_tag` output

## Testing ✅

Successfully verified by manually triggering the workflow with a SHA tag:
- Workflow run: https://github.com/lissto-dev/cli/actions/runs/21265291521
- Published image: `lissto/cli:sha-a51e594`

## Related Issue

Fixes failed run: https://github.com/lissto-dev/cli/actions/runs/21264437907/job/61199920066