### PR TITLE
Upgrade Go version from 1.24.11 to 1.25.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lissto-dev/cli
 
-go 1.24.11
+go 1.25.6
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
## Summary
This PR upgrades the Go version from 1.24.11 to 1.25.6 (latest stable).

## Changes
- Updated `go.mod` to use Go 1.25.6
- Ran `go mod tidy` to update dependencies

## Testing
- ✅ `make build` - successful
- ✅ `make test` - all tests passing

## Notes
- GitHub Actions workflows already use `go-version-file: go.mod` so they will automatically pick up the new version

@daniel-ro can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)